### PR TITLE
add: post 관련 타입 추가(#38)

### DIFF
--- a/src/types/postTypes.ts
+++ b/src/types/postTypes.ts
@@ -1,0 +1,20 @@
+export interface PostType {
+  id?: number;
+  pr_link?: string;
+  contents?: string;
+  created_at?: string;
+  updated_at?: string;
+  deleted_at?: string;
+}
+
+export interface PostItemType extends PostType {
+  id: number;
+  pr_link: string;
+  contents: string;
+  created_at: string;
+}
+
+export interface PostRequestType extends PostType {
+  pr_link: string;
+  contents: string;
+}


### PR DESCRIPTION
## post 관련 타입 추가
- PostType: 기본 타입
- PostItemType: 응답, 리스트의 아이템의 타입으로 사용
- PostRequestType: 요청할 때의 필수 속성

closes #38

## 리뷰어에게
@hhkim0729  @srngch  @s2lululala 