### PR TITLE
add: FormContentTextarea 추가

### DIFF
--- a/src/components/Form/FormContentTextarea.tsx
+++ b/src/components/Form/FormContentTextarea.tsx
@@ -1,29 +1,34 @@
-import React, { useState } from 'react'
+import React, { useState } from 'react';
 
 interface FormContentTextareaProp {
-  value:string;
+  value: string;
   // eslint-disable-next-line
-  setValue: (value:string) => void;
+  setValue: (value: string) => void;
 }
 
-const maxContentLength = 300; 
+const maxContentLength = 300;
 
-const FormContentTextarea = ({value, setValue} : FormContentTextareaProp) => {
-  const [errorMessage, setErrorMessage] = useState("");
+const FormContentTextarea = ({ value, setValue }: FormContentTextareaProp) => {
+  const [errorMessage, setErrorMessage] = useState('');
   const handleChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
     const { value } = event.currentTarget;
     setValue(value);
     if (!errorMessage && value.length >= maxContentLength)
-      setErrorMessage(`최대 ${maxContentLength}자까지만 입력 가능합니다.`)
+      setErrorMessage(`최대 ${maxContentLength}자까지만 입력 가능합니다.`);
     else if (errorMessage && value.length < maxContentLength)
-      setErrorMessage("");
-  }
+      setErrorMessage('');
+  };
   return (
     <>
-      <textarea value= {value} onChange= {handleChange} maxLength={maxContentLength} required/>
+      <textarea
+        value={value}
+        onChange={handleChange}
+        maxLength={maxContentLength}
+        required
+      />
       {errorMessage && <p>{errorMessage}</p>}
     </>
-  )
-}
+  );
+};
 
-export default FormContentTextarea
+export default FormContentTextarea;

--- a/src/components/Form/FormContentTextarea.tsx
+++ b/src/components/Form/FormContentTextarea.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react'
+
+interface FormContentTextareaProp {
+  value:string;
+  // eslint-disable-next-line
+  setValue: (value:string) => void;
+}
+
+const maxContentLength = 300; 
+
+const FormContentTextarea = ({value, setValue} : FormContentTextareaProp) => {
+  const [errorMessage, setErrorMessage] = useState("");
+  const handleChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    const { value } = event.currentTarget;
+    setValue(value);
+    if (!errorMessage && value.length >= maxContentLength)
+      setErrorMessage(`최대 ${maxContentLength}자까지만 입력 가능합니다.`)
+    else if (errorMessage && value.length < maxContentLength)
+      setErrorMessage("");
+  }
+  return (
+    <>
+      <textarea value= {value} onChange= {handleChange} maxLength={maxContentLength} required/>
+      {errorMessage && <p>{errorMessage}</p>}
+    </>
+  )
+}
+
+export default FormContentTextarea


### PR DESCRIPTION
## 작업 내용
- Form에 들어가는 textarea 컴포넌트를 추가했습니다.
- PrLinkInput 컴포넌트와 마찬가지로 상위 Form에서 value와 setter를 상속받도록 처리했습니다.
- maxContentLength로 설정된 글자수가 초과되면 에러메세지를 노출합니다.

closes #28 

## 리뷰어에게
- prop 타입 정의할 때 `setValue: (value:string) => void;` 에서 eslint 오류가 발생해서 주석을 추가했습니다. 
<img width="524" alt="image" src="https://user-images.githubusercontent.com/74622889/178471600-4dcfd4f3-6b7d-4c9e-ba9e-992abee0eb71.png">

- 어떻게 수정하면 좋을지 의견주시면 적극 반영하겠습니다! 
