### PR TITLE
fix:  패치 로딩 중 data 가 없을 때 화면이 뜨지 않는 이슈 고침

### DIFF
--- a/src/components/PostDetail/index.tsx
+++ b/src/components/PostDetail/index.tsx
@@ -24,7 +24,7 @@ const PostDetail = () => {
     <section>
       {isLoading && <div>Loading...</div>}
       {!isLoading && error && <div>error...</div>}
-      {!isLoading && data.data && (
+      {!isLoading && data?.data && (
         <PostItem
           id={data.data.id}
           prLink={data.data.attributes.prLink}


### PR DESCRIPTION
## 작업 내용
- 포스트 상세페이지로 접근했을 때 빈 화면이 뜨는 문제
- closes #112

## 리뷰어에게
- 라우트가 아니라 #106 과 관련된 이슈였습니다...!
- 혹시 다른 페이지에서도 화면이 뜨지 않는다면 같은 방식으로 수정하시면 되겠습니다