### PR TITLE
update: 수정 완료 후 포스트 상세 페이지로 이동

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -10,7 +10,7 @@ import { API_ORIGIN } from 'constants/index';
 
 const Form = () => {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [postRequest, setPostRequest] = useState<PostRequestType>({
     contents: '',
     prLink: '',


### PR DESCRIPTION
## 작업 내용
- #71
- react-router의 useLocation 대신 react-router-dom의 useSearchParams 사용
  - useLocation을 사용할 경우, location.search의 문자열을 파싱하기 위해서 별도의 코드가 필요하거나 qs 같은 추가 라이브러리가 필요함
  - 이미 사용중인 react-router-dom에서 제공하는 useSearchParams 훅을 사용한다면 파싱할 필요 없이 제공하는 getter로 원하는 쿼리스트링을 가져올 수 있음

closes #71

## 리뷰어에게
브라우저 콘솔 창에 뜨는 워닝을 해결하고 싶은데 무슨 문제일까요..